### PR TITLE
new xml settings systems PR

### DIFF
--- a/Assets/Scripts/Controllers/WorldController.cs
+++ b/Assets/Scripts/Controllers/WorldController.cs
@@ -170,10 +170,14 @@ public class WorldController : MonoBehaviour
         SceneManager.LoadScene(SceneManager.GetActiveScene().name);
     }
 
-    void CreateEmptyWorld()
+     void CreateEmptyWorld()
     {
+        //get world size from settings
+        int width = int.Parse(Settings.getSetting("worldWidth"));
+        int height = int.Parse(Settings.getSetting("worldHeight"));
+
         // Create a world with Empty tiles
-        world = new World(100, 100);
+        world = new World(width, height);
 
         // Center the Camera
         Camera.main.transform.position = new Vector3(world.Width / 2, world.Height / 2, Camera.main.transform.position.z);

--- a/Assets/Scripts/Models/World.cs
+++ b/Assets/Scripts/Models/World.cs
@@ -56,8 +56,11 @@ public class World : IXmlSerializable
     /// <param name="height">Height in tiles.</param>
     public World(int width, int height)
     {
-        // Creates an empty world.
+       // Creates an empty world.
         SetupWorld(width, height);
+
+        //log size of world
+        Debug.Log("creating new world of size [ " + width + "," + height + " ]");
 
         // Make one character
         CreateCharacter(GetTileAt(Width / 2, Height / 2));

--- a/Assets/Scripts/Utilities/Settings.cs
+++ b/Assets/Scripts/Utilities/Settings.cs
@@ -1,0 +1,69 @@
+﻿using UnityEngine;
+using System.Collections.Generic;
+using System;
+using System.Xml;
+using System.Xml.Schema;
+using System.Xml.Serialization;
+using System.IO;
+
+public static class Settings {
+
+    private static Dictionary<string,string> settingsDict;
+
+
+	public static string getSetting( string key )
+	{
+
+        // if we haven't already loaded our settings do it now
+		if (settingsDict == null) 
+		{
+			loadSettings ();
+		}
+
+
+        string value;
+
+        // attempt to get the requested setting, if it is not found log a warning and return the null string
+        if (settingsDict.TryGetValue(key,out value) == false)
+        {
+            Debug.LogWarning("Atempted to access a setting that was not loaded from Settings.xml :\t" + key);
+        }
+
+        return value;
+	}
+
+	private static void loadSettings()
+	{
+        // initilize the settings dict
+        settingsDict = new Dictionary<string, string>();
+
+        // get file path of Settings.xml and load the text
+		string filePath = System.IO.Path.Combine(Application.streamingAssetsPath, "Settings.xml");
+		string furnitureXmlText = System.IO.File.ReadAllText(filePath);
+
+        // create an xml document from Settings.xml
+        XmlDocument xDoc = new XmlDocument();
+        xDoc.LoadXml(furnitureXmlText);
+        Debug.Log("Loaded settings from : \t" + filePath );
+
+        // get the Settings node , it's children are the individual settings
+        XmlNode settingsNode = xDoc.GetElementsByTagName("Settings").Item(0);
+        XmlNodeList settingNodes = settingsNode.ChildNodes;
+        Debug.Log(settingNodes.Count+" settings loaded");
+
+        //loop for each setting
+        foreach (XmlNode node in settingNodes)
+        {
+            if (node != null)
+            {
+                // add setting to the settings dict
+                settingsDict.Add(node.Name, node.InnerText);
+
+                // commented out to avoid console spam with large Settings.xml files
+                // Debug.Log( node.Name + " : " + node.InnerText );
+            }
+        }
+       
+	}
+
+}

--- a/Assets/Scripts/Utilities/Settings.cs.meta
+++ b/Assets/Scripts/Utilities/Settings.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 6ce4548579ea1144d8174334839f87fe
+timeCreated: 1471519352
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/StreamingAssets/Settings.xml
+++ b/Assets/StreamingAssets/Settings.xml
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<Settings>
+	<localisation>en</localisation>
+	<worldWidth>110</worldWidth>
+	<worldHeight>110</worldHeight>
+</Settings>

--- a/Assets/StreamingAssets/Settings.xml.meta
+++ b/Assets/StreamingAssets/Settings.xml.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fe96a61012483ff4fa1575ad14f2a4fe
+timeCreated: 1471519351
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
a new branch and PR becuse of messy commits in previous branch #121

Added a static Settings class that reads in settings from Settings.xml ,
values of these can be accessed via Settings.getSetting(string key)

Changed world controller to use this system when making a new world.
World size is now controlled by Settings.xml

Adds a couple of debug statements that only log once.

implements settings file as suggested in #21
